### PR TITLE
Update information about Migrate Source CSV.

### DIFF
--- a/index.html
+++ b/index.html
@@ -245,7 +245,7 @@
                     <li>Migrate Upgrade provides basic Drush support.</li>
                     <li>Migrate Tools provides Drush commands to migrate, rollback, reset status and view status.</li>
                     <li>Migrate Plus provides grouping migrations and additional process plugins.</li>
-                    <li>Migrate Source CSV allows migrating content from a CSV file instead of a database; is moving to core.</li>
+                    <li>Migrate Source CSV allows migrating content from a CSV file instead of a database.</li>
                 </ul>
             </aside>
         </section>


### PR DESCRIPTION
Removes mention of moving the module's functionality to core, as the issue for that has been closed.